### PR TITLE
Blueprint CLI: ListBlueprintInstallations + UninstallBlueprint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Environment variables are prefixed with `OCTO_`.
 | Category | Commands | Service |
 |----------|----------|---------|
 | Identity | users, roles, clients, identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
-| Asset | tenants, models, blueprints (ListBlueprints, InstallBlueprint, GetBlueprintHistory, PreviewBlueprintUpdate, UpdateBlueprint, ListBlueprintBackups, RollbackBlueprint), timeSeries (EnableStreamData, DisableStreamData, ActivateArchive, DisableArchive, EnableArchive, RetryArchiveActivation, DeleteArchive, FreezeRollupArchive, UnfreezeRollupArchive, RewindRollupWatermark, ListRollupsForArchive) | Asset Repository |
+| Asset | tenants, models, blueprints (ListBlueprints, InstallBlueprint, GetBlueprintHistory, PreviewBlueprintUpdate, UpdateBlueprint, ListBlueprintBackups, RollbackBlueprint, ListBlueprintInstallations, UninstallBlueprint), timeSeries (EnableStreamData, DisableStreamData, ActivateArchive, DisableArchive, EnableArchive, RetryArchiveActivation, DeleteArchive, FreezeRollupArchive, UnfreezeRollupArchive, RewindRollupWatermark, ListRollupsForArchive) | Asset Repository |
 | Bots | notifications | Bot Services |
 | Communication | enable/disable, adapters, pipelines, triggers, pools, dataFlows | Communication Controller |
 | Reporting | enable/disable | Report Services |
@@ -180,6 +180,12 @@ octo-cli -c ListBlueprints                                          # list catal
 octo-cli -c InstallBlueprint -b MyBlueprint-1.0.0                   # apply blueprint to the active tenant
 octo-cli -c InstallBlueprint -b MyBlueprint-1.0.0 -f                # re-apply seed data via upsert (recovery)
 octo-cli -c GetBlueprintHistory                                     # show application history for the active tenant
+
+# Blueprints — multi-install + uninstall (Phase 3)
+octo-cli -c ListBlueprintInstallations                              # list blueprints currently installed on the tenant
+octo-cli -c UninstallBlueprint -n MyBlueprint                       # uninstall a blueprint (locked owned entities erased)
+octo-cli -c UninstallBlueprint -n MyBlueprint -c                    # cascade: also remove dependents and orphan deps
+octo-cli -c UninstallBlueprint -n MyBlueprint -y                    # skip the confirmation prompt
 
 # Blueprints — update + rollback (Phase 2a: operations layer; richer diff/merge in Phase 2b)
 octo-cli -c PreviewBlueprintUpdate -tv MyBlueprint-2.0.0            # preview changes a target version would apply (Merge mode)
@@ -342,6 +348,7 @@ All destructive commands (Delete, Clean, Reset, Remove) require interactive user
 | `DeleteApiSecretClient` | `delete API secret for client '{clientId}'` |
 | `DeleteArchive` | `delete archive '{archiveRtId}'? The CrateDB table will be dropped and historical data lost` |
 | `RollbackBlueprint` | `rollback tenant '{tenantId}' to backup '{backupId}'? Current tenant data will be replaced` |
+| `UninstallBlueprint` | `uninstall blueprint '{name}' from tenant '{tenantId}'[ together with any blueprints that depend on it and any orphaned dependencies]? Locked owned entities will be erased` |
 
 ### Usage Examples
 

--- a/src/ManagementTool/Commands/Implementations/Asset/Blueprints/ListBlueprintInstallations.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/Blueprints/ListBlueprintInstallations.cs
@@ -1,0 +1,50 @@
+using Meshmakers.Common.Shared.Services;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.AssetRepositoryServices.System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Asset.Blueprints;
+
+internal class ListBlueprintInstallations : ServiceClientOctoCommand<IAssetServicesClient>
+{
+    private readonly IConsoleService _consoleService;
+
+    public ListBlueprintInstallations(
+        ILogger<ListBlueprintInstallations> logger,
+        IConsoleService consoleService,
+        IOptions<OctoToolOptions> options,
+        IAssetServicesClient assetServicesClient,
+        IAuthenticationService authenticationService)
+        : base(logger, Constants.AssetRepositoryServicesGroup, "ListBlueprintInstallations",
+            "Lists all blueprints currently installed on the active tenant.",
+            options, assetServicesClient, authenticationService)
+    {
+        _consoleService = consoleService;
+    }
+
+    public override async Task Execute()
+    {
+        if (string.IsNullOrWhiteSpace(Options.Value.TenantId))
+        {
+            Logger.LogError("TenantId is missing - configure it via the active context");
+            return;
+        }
+
+        Logger.LogInformation(
+            "Listing blueprint installations for tenant '{TenantId}' at '{ServiceClientServiceUri}'",
+            Options.Value.TenantId, ServiceClient.ServiceUri);
+
+        var installations = await ServiceClient.ListBlueprintInstallationsAsync(Options.Value.TenantId);
+
+        if (installations.Count == 0)
+        {
+            Logger.LogInformation("No blueprints installed on tenant '{TenantId}'", Options.Value.TenantId);
+            return;
+        }
+
+        var resultString = JsonConvert.SerializeObject(installations, Formatting.Indented);
+        _consoleService.WriteLine(resultString);
+    }
+}

--- a/src/ManagementTool/Commands/Implementations/Asset/Blueprints/UninstallBlueprint.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/Blueprints/UninstallBlueprint.cs
@@ -1,0 +1,96 @@
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Common.Shared.Services;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.AssetRepositoryServices.System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Asset.Blueprints;
+
+internal class UninstallBlueprint : ServiceClientOctoCommand<IAssetServicesClient>
+{
+    private readonly IConsoleService _consoleService;
+    private readonly IConfirmationService _confirmationService;
+    private readonly IArgument _blueprintNameArg;
+    private readonly IArgument _cascadeArg;
+    private readonly IArgument _yesArg;
+
+    public UninstallBlueprint(
+        ILogger<UninstallBlueprint> logger,
+        IConsoleService consoleService,
+        IConfirmationService confirmationService,
+        IOptions<OctoToolOptions> options,
+        IAssetServicesClient assetServicesClient,
+        IAuthenticationService authenticationService)
+        : base(logger, Constants.AssetRepositoryServicesGroup, "UninstallBlueprint",
+            "Removes a blueprint from the active tenant; with --cascade, dependents and orphan dependencies go too.",
+            options, assetServicesClient, authenticationService)
+    {
+        _consoleService = consoleService;
+        _confirmationService = confirmationService;
+
+        _blueprintNameArg = CommandArgumentValue.AddArgument("n", "blueprintName",
+            ["Blueprint name (without version), e.g. 'MyBlueprint'"], true, 1);
+
+        _cascadeArg = CommandArgumentValue.AddArgument("c", "cascade",
+            ["Also uninstall blueprints that depend on the target, and orphan dependencies of the target"],
+            false, 0);
+
+        _yesArg = CommandArgumentValue.AddArgument("y", "yes",
+            ["Skip the interactive confirmation prompt"], false, 0);
+    }
+
+    public override async Task Execute()
+    {
+        if (string.IsNullOrWhiteSpace(Options.Value.TenantId))
+        {
+            Logger.LogError("TenantId is missing - configure it via the active context");
+            return;
+        }
+
+        var blueprintName = CommandArgumentValue.GetArgumentScalarValue<string>(_blueprintNameArg);
+        var cascade = CommandArgumentValue.IsArgumentUsed(_cascadeArg);
+        var skipConfirmation = CommandArgumentValue.IsArgumentUsed(_yesArg);
+
+        var promptDetail = cascade
+            ? $" together with any blueprints that depend on it and any orphaned dependencies"
+            : string.Empty;
+
+        if (!skipConfirmation && !_confirmationService.Confirm(
+                $"uninstall blueprint '{blueprintName}' from tenant '{Options.Value.TenantId}'{promptDetail}? Locked owned entities will be erased"))
+        {
+            throw ToolException.OperationCancelledByUser();
+        }
+
+        Logger.LogInformation(
+            "Uninstalling blueprint '{BlueprintName}' from tenant '{TenantId}' (cascade={Cascade})",
+            blueprintName, Options.Value.TenantId, cascade);
+
+        var result = await ServiceClient.UninstallBlueprintAsync(
+            Options.Value.TenantId, blueprintName, cascade);
+
+        if (!result.Success)
+        {
+            if (result.BlockingDependents.Count > 0)
+            {
+                Logger.LogError(
+                    "Uninstall blocked: '{BlueprintName}' is still required by {Dependents}. Re-run with --cascade to remove them as well.",
+                    blueprintName, string.Join(", ", result.BlockingDependents));
+            }
+            else
+            {
+                Logger.LogError("Uninstall failed");
+            }
+
+            _consoleService.WriteLine(JsonConvert.SerializeObject(result, Formatting.Indented));
+            return;
+        }
+
+        Logger.LogInformation(
+            "Uninstall complete: {EntitiesDeleted} entities erased, {CascadedCount} cascaded blueprints",
+            result.EntitiesDeleted, result.CascadedDependencies.Count);
+
+        _consoleService.WriteLine(JsonConvert.SerializeObject(result, Formatting.Indented));
+    }
+}

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -252,6 +252,8 @@ internal static class Program
         services.AddTransient<ICommand, UpdateBlueprint>();
         services.AddTransient<ICommand, ListBlueprintBackups>();
         services.AddTransient<ICommand, RollbackBlueprint>();
+        services.AddTransient<ICommand, ListBlueprintInstallations>();
+        services.AddTransient<ICommand, UninstallBlueprint>();
 
         services.AddTransient<ICommand, GetClients>();
         services.AddTransient<ICommand, GetClient>();


### PR DESCRIPTION
## Summary
- \`ListBlueprintInstallations\` — shows the live installation rows on the active tenant.
- \`UninstallBlueprint -n <name> [-c] [-y]\` — removes a blueprint; \`-c\` switches on cascade; destructive so it prompts unless \`-y\` is given.
- CLAUDE.md updates: command-categories table, usage examples, confirmation-dialog matrix.

## Test plan
- [x] \`dotnet build -c DebugL\` clean.
- [x] Both commands appear in \`octo-cli\` help output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)