### PR TITLE
4209-feat(cli): ApplyClientOverlay command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Environment variables are prefixed with `OCTO_`.
 
 | Category | Commands | Service |
 |----------|----------|---------|
-| Identity | users, roles, clients (+ mirror commands: GetClientMirrors, ProvisionClientInExistingTenants, ProvisionClientInTenant, UnprovisionClientFromTenant, SetClientAutoProvision), identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
+| Identity | users, roles, clients (+ mirror commands: GetClientMirrors, ProvisionClientInExistingTenants, ProvisionClientInTenant, UnprovisionClientFromTenant, SetClientAutoProvision, ApplyClientOverlay), identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
 | Asset | tenants, models, blueprints (ListBlueprints, InstallBlueprint, GetBlueprintHistory, PreviewBlueprintUpdate, UpdateBlueprint, ListBlueprintBackups, RollbackBlueprint, ListBlueprintInstallations, UninstallBlueprint), timeSeries (EnableStreamData, DisableStreamData, ActivateArchive, DisableArchive, EnableArchive, RetryArchiveActivation, DeleteArchive, FreezeRollupArchive, UnfreezeRollupArchive, RewindRollupWatermark, ListRollupsForArchive) | Asset Repository |
 | Bots | Dump, Restore, RunFixupScripts | Bot Services |
 | Communication | enable/disable, adapters, pipelines (incl. MovePipelines for bulk reassignment to a different adapter), triggers, pools, dataFlows, workloads (GetWorkloadsByChart, UpdateWorkloadChartVersion, DeployWorkload, UndeployWorkload) | Communication Controller |
@@ -284,6 +284,15 @@ octo-cli -c UnprovisionClientFromTenant -id ci-deploy -ctid acme
 # Flip the AutoProvisionInChildTenants flag on an existing client.
 # Note: flipping true does NOT auto-backfill — use ProvisionClientInExistingTenants for that.
 octo-cli -c SetClientAutoProvision -id ci-deploy -e true
+
+# Client overlay URIs (AB#4209 Step 4) — append operator-scoped URIs onto blueprint-managed
+# clients (e.g. local-dev callbacks on the Refinery Studio client) without modifying the
+# blueprint. Entries are written with Source = "overlay:<OverlayName>" and survive blueprint
+# re-apply via the Step 2a preservation pass. Idempotent — duplicates silently skipped.
+octo-cli -c ApplyClientOverlay -id octo-data-refinery-studio -n local-dev \
+  -r "http://localhost:4200/auth-callback,http://localhost:4200/silent-callback" \
+  -plr "http://localhost:4200/" \
+  -co "http://localhost:4200"
 
 # OctoTenant identity provider (cross-tenant auth)
 octo-cli -c AddOctoTenantIdentityProvider -n "ParentTenant" -e true -ptid <parentTenantId>

--- a/src/ManagementTool/Commands/Implementations/Identity/Clients/ApplyClientOverlay.cs
+++ b/src/ManagementTool/Commands/Implementations/Identity/Clients/ApplyClientOverlay.cs
@@ -1,0 +1,111 @@
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Octo.Communication.Contracts.DataTransferObjects;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.IdentityServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Identity.Clients;
+
+internal class ApplyClientOverlay : ServiceClientOctoCommand<IIdentityServicesClient>
+{
+    private readonly IArgument _clientId;
+    private readonly IArgument _overlayName;
+    private readonly IArgument _redirectUris;
+    private readonly IArgument _postLogoutRedirectUris;
+    private readonly IArgument _allowedCorsOrigins;
+
+    public ApplyClientOverlay(ILogger<ApplyClientOverlay> logger, IOptions<OctoToolOptions> options,
+        IIdentityServicesClient identityServicesClient, IAuthenticationService authenticationService)
+        : base(logger, Constants.IdentityServicesGroup, "ApplyClientOverlay",
+            "Applies an overlay URI set (RedirectUris / PostLogoutRedirectUris / AllowedCorsOrigins) " +
+            "to a blueprint-managed client. New entries are written with Source = 'overlay:<OverlayName>', " +
+            "kept across blueprint re-apply by the Step 2a preservation pass. Idempotent — duplicates are " +
+            "silently skipped (any source). At least one of the three URI lists must be provided.",
+            options, identityServicesClient, authenticationService)
+    {
+        _clientId = CommandArgumentValue.AddArgument("id", "clientId",
+            ["The ClientId to apply the overlay to. Must already exist."], true, 1);
+        _overlayName = CommandArgumentValue.AddArgument("n", "overlayName",
+            ["Operator-meaningful overlay name. Becomes the suffix of 'overlay:<OverlayName>' on every " +
+             "persisted entry. Constrained to [A-Za-z0-9._-]+."],
+            true, 1);
+        _redirectUris = CommandArgumentValue.AddArgument("r", "redirectUris",
+            ["Comma-separated list of redirect URIs to add"], false, 1);
+        _postLogoutRedirectUris = CommandArgumentValue.AddArgument("plr", "postLogoutRedirectUris",
+            ["Comma-separated list of post-logout redirect URIs to add"], false, 1);
+        _allowedCorsOrigins = CommandArgumentValue.AddArgument("co", "allowedCorsOrigins",
+            ["Comma-separated list of CORS origins to add (pass without trailing slash)"], false, 1);
+    }
+
+    public override CommandDocumentation? GetDocumentation() =>
+        new(
+            Samples:
+            [
+                new CodeSample(
+                    arguments:
+                    [
+                        new CodeSampleArgument(_clientId, "octo-data-refinery-studio"),
+                        new CodeSampleArgument(_overlayName, "local-dev"),
+                        new CodeSampleArgument(_redirectUris, "http://localhost:4200/auth-callback,http://localhost:4200/silent-callback"),
+                        new CodeSampleArgument(_postLogoutRedirectUris, "http://localhost:4200/"),
+                        new CodeSampleArgument(_allowedCorsOrigins, "http://localhost:4200"),
+                    ],
+                    description: "Inject the local-dev redirect / post-logout / CORS triple into the Refinery Studio client"),
+                new CodeSample(
+                    arguments:
+                    [
+                        new CodeSampleArgument(_clientId, "octo-data-refinery-studio"),
+                        new CodeSampleArgument(_overlayName, "local-dev"),
+                        new CodeSampleArgument(_redirectUris, "http://localhost:4200/auth-callback"),
+                    ],
+                    description: "Single-list usage — only RedirectUris is added; other lists are untouched"),
+            ],
+            Notes:
+            [
+                "Re-running with the same payload is a no-op: every URI hits the dedup branch, no DB write, no cache invalidation.",
+                "Server returns 400 if every supplied list is empty / whitespace-only.",
+                "The endpoint does not strip trailing slashes from CORS origins — pass origin-shaped values yourself.",
+            ]);
+
+    public override async Task Execute()
+    {
+        var clientId = CommandArgumentValue.GetArgumentScalarValue<string>(_clientId);
+        var overlayName = CommandArgumentValue.GetArgumentScalarValue<string>(_overlayName);
+
+        var dto = new ApplyOverlayUrisDto
+        {
+            OverlayName = overlayName,
+            RedirectUris = ParseCommaSeparatedList(_redirectUris),
+            PostLogoutRedirectUris = ParseCommaSeparatedList(_postLogoutRedirectUris),
+            AllowedCorsOrigins = ParseCommaSeparatedList(_allowedCorsOrigins)
+        };
+
+        Logger.LogInformation(
+            "Applying overlay '{OverlayName}' to client '{ClientId}' at '{ServiceClientServiceUri}'",
+            overlayName, clientId, ServiceClient.ServiceUri);
+
+        var result = await ServiceClient.ApplyClientOverlay(clientId, dto);
+
+        Logger.LogInformation(
+            "Overlay '{OverlayName}' on '{ClientId}' applied: " +
+            "RedirectUris={RAdd} added / {RSkip} skipped, " +
+            "PostLogoutRedirectUris={PLAdd} added / {PLSkip} skipped, " +
+            "AllowedCorsOrigins={COAdd} added / {COSkip} skipped",
+            result.OverlayName, result.ClientId,
+            result.RedirectUris.Added, result.RedirectUris.SkippedDuplicate,
+            result.PostLogoutRedirectUris.Added, result.PostLogoutRedirectUris.SkippedDuplicate,
+            result.AllowedCorsOrigins.Added, result.AllowedCorsOrigins.SkippedDuplicate);
+    }
+
+    private List<string>? ParseCommaSeparatedList(IArgument argument)
+    {
+        if (!CommandArgumentValue.IsArgumentUsed(argument))
+        {
+            return null;
+        }
+
+        var value = CommandArgumentValue.GetArgumentScalarValue<string>(argument);
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+    }
+}

--- a/src/ManagementTool/Commands/Implementations/Identity/Clients/ApplyClientOverlay.cs
+++ b/src/ManagementTool/Commands/Implementations/Identity/Clients/ApplyClientOverlay.cs
@@ -73,12 +73,27 @@ internal class ApplyClientOverlay : ServiceClientOctoCommand<IIdentityServicesCl
         var clientId = CommandArgumentValue.GetArgumentScalarValue<string>(_clientId);
         var overlayName = CommandArgumentValue.GetArgumentScalarValue<string>(_overlayName);
 
+        var redirectUris = ParseCommaSeparatedList(_redirectUris);
+        var postLogoutRedirectUris = ParseCommaSeparatedList(_postLogoutRedirectUris);
+        var allowedCorsOrigins = ParseCommaSeparatedList(_allowedCorsOrigins);
+
+        // Client-side guard: matches the server's 400 on empty payloads. Catches the
+        // common typo case (`-r " , "` trims to zero entries) before a roundtrip so the
+        // operator gets a CLI-shaped error instead of a wrapped HTTP exception.
+        if ((redirectUris == null || redirectUris.Count == 0) &&
+            (postLogoutRedirectUris == null || postLogoutRedirectUris.Count == 0) &&
+            (allowedCorsOrigins == null || allowedCorsOrigins.Count == 0))
+        {
+            throw new ToolException(
+                "At least one of -r / -plr / -co must contain a non-whitespace URI.");
+        }
+
         var dto = new ApplyOverlayUrisDto
         {
             OverlayName = overlayName,
-            RedirectUris = ParseCommaSeparatedList(_redirectUris),
-            PostLogoutRedirectUris = ParseCommaSeparatedList(_postLogoutRedirectUris),
-            AllowedCorsOrigins = ParseCommaSeparatedList(_allowedCorsOrigins)
+            RedirectUris = redirectUris,
+            PostLogoutRedirectUris = postLogoutRedirectUris,
+            AllowedCorsOrigins = allowedCorsOrigins
         };
 
         Logger.LogInformation(

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -284,6 +284,9 @@ internal static class Program
         services.AddTransient<ICommand, UnprovisionClientFromTenant>();
         services.AddTransient<ICommand, SetClientAutoProvision>();
 
+        // AB#4209 Step 4 PR 2 — overlay URI write for blueprint-managed clients
+        services.AddTransient<ICommand, ApplyClientOverlay>();
+
         services.AddTransient<ICommand, GetIdentityProviders>();
         services.AddTransient<ICommand, AddOAuthIdentityProvider>();
         services.AddTransient<ICommand, AddOpenLdapIdentityProvider>();


### PR DESCRIPTION
## Summary

[AB#4209](https://dev.azure.com/meshmakers/c85af059-45e1-40ff-9229-52bc69642d53/_workitems/edit/4209) Step 4 PR 2 — octo-cli side. Adds the `ApplyClientOverlay` command that calls the new identity-services REST endpoint `POST {tenantId}/v1/clients/{id}/overlayUris` (shipped on octo-identity-services PR #102) via the new SDK client method `IIdentityServicesClient.ApplyClientOverlay` (octo-sdk PR #37, sibling of this PR).

### Changes

- `src/ManagementTool/Commands/Implementations/Identity/Clients/ApplyClientOverlay.cs` (new) — 5 args, comma-separated lists, full `GetDocumentation()` override with 2 code samples + 3 notes.
- `src/ManagementTool/Program.cs` — register the command alongside the existing client-mirror commands.
- `CLAUDE.md` — append to the Identity command-category row + add a usage block under the multi-tenant ClientCredentials examples.

### Args

| Short | Long | Required | Description |
|-------|------|----------|-------------|
| `-id` | `--clientId` | yes | Blueprint-managed client to overlay |
| `-n` | `--overlayName` | yes | Becomes 'overlay:&lt;n&gt;' Source marker |
| `-r` | `--redirectUris` | no | Comma-separated, added to RedirectUris |
| `-plr` | `--postLogoutRedirectUris` | no | Comma-separated, added to PostLogoutRedirectUris |
| `-co` | `--allowedCorsOrigins` | no | Comma-separated, added to AllowedCorsOrigins |

### Behaviour

At least one of the three lists must contain a non-whitespace URI; otherwise the server returns 400 (handled by the existing `Octo.Sdk.ServiceClient` HTTP error path). Duplicates against the existing client URIs (any source) are skipped silently. Re-running with the same payload is a no-op (every URI hits dedup, no DB write, no cache invalidation) — designed for safe inclusion in Start-Octo / CI bootstrap scripts.

### Next step

Final consumer is the octo-tools `Apply-IdentityOverlay.psm1` cmdlet (PR 3) which fans this command out across the blueprint-managed clients in a single Start-Octo call.

## Test plan

- [x] `dotnet build Octo.Cli.sln -c DebugL` — green
- [x] `dotnet test Octo.Cli.sln -c DebugL` — 43/43 green
- [x] `octo-cli -c ApplyClientOverlay --help` shows correct argument list
- [x] `octo-cli -c ApplyClientOverlay` (no args) prints \"Mandatory arguments are missing: --clientId (-id), --overlayName (-n)\" — argument parser hooks fire
- [ ] CI green on this PR (depends on octo-sdk PR #37 NuGet being available)
- [ ] End-to-end smoke against local Identity: `octo-cli -c ApplyClientOverlay -id octo-data-refinery-studio -n local-dev -r http://localhost:4200/auth-callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)