### PR TITLE
4209-feat(cli): CleanClientOverlays command (Step 5 PR 4')

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Environment variables are prefixed with `OCTO_`.
 
 | Category | Commands | Service |
 |----------|----------|---------|
-| Identity | users, roles, clients (+ mirror commands: GetClientMirrors, ProvisionClientInExistingTenants, ProvisionClientInTenant, UnprovisionClientFromTenant, SetClientAutoProvision, ApplyClientOverlay), identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
+| Identity | users, roles, clients (+ mirror commands: GetClientMirrors, ProvisionClientInExistingTenants, ProvisionClientInTenant, UnprovisionClientFromTenant, SetClientAutoProvision, ApplyClientOverlay, CleanClientOverlays), identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
 | Asset | tenants, models, blueprints (ListBlueprints, InstallBlueprint, GetBlueprintHistory, PreviewBlueprintUpdate, UpdateBlueprint, ListBlueprintBackups, RollbackBlueprint, ListBlueprintInstallations, UninstallBlueprint), timeSeries (EnableStreamData, DisableStreamData, ActivateArchive, DisableArchive, EnableArchive, RetryArchiveActivation, DeleteArchive, FreezeRollupArchive, UnfreezeRollupArchive, RewindRollupWatermark, ListRollupsForArchive) | Asset Repository |
 | Bots | Dump, Restore, RunFixupScripts | Bot Services |
 | Communication | enable/disable, adapters, pipelines (incl. MovePipelines for bulk reassignment to a different adapter), triggers, pools, dataFlows, workloads (GetWorkloadsByChart, UpdateWorkloadChartVersion, DeployWorkload, UndeployWorkload) | Communication Controller |
@@ -293,6 +293,15 @@ octo-cli -c ApplyClientOverlay -id octo-data-refinery-studio -n local-dev \
   -r "http://localhost:4200/auth-callback,http://localhost:4200/silent-callback" \
   -plr "http://localhost:4200/" \
   -co "http://localhost:4200"
+
+# Strip overlay URIs (AB#4209 Step 5) — destructive cleanup before a sanitised tenant dump.
+# Without -n: removes every overlay:* source. With -n: removes only overlay:<name>.
+# Typical workflow before sharing a dump:
+#   octo-cli -c CleanClientOverlays -y && octo-cli -c DumpTenant -tid mytenant ...
+# After dumping, restore the local-dev overlays via the cmdlet (idempotent):
+#   Apply-IdentityOverlay
+octo-cli -c CleanClientOverlays                         # strip all overlay:* (prompts)
+octo-cli -c CleanClientOverlays -n local-dev -y         # strip only overlay:local-dev, skip prompt
 
 # OctoTenant identity provider (cross-tenant auth)
 octo-cli -c AddOctoTenantIdentityProvider -n "ParentTenant" -e true -ptid <parentTenantId>

--- a/src/ManagementTool/Commands/Implementations/Identity/Clients/CleanClientOverlays.cs
+++ b/src/ManagementTool/Commands/Implementations/Identity/Clients/CleanClientOverlays.cs
@@ -1,0 +1,92 @@
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.IdentityServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Identity.Clients;
+
+internal class CleanClientOverlays : ServiceClientOctoCommand<IIdentityServicesClient>
+{
+    private readonly IConfirmationService _confirmationService;
+    private readonly IArgument _overlayName;
+    private readonly IArgument _yesArg;
+
+    public CleanClientOverlays(ILogger<CleanClientOverlays> logger, IOptions<OctoToolOptions> options,
+        IIdentityServicesClient identityServicesClient, IAuthenticationService authenticationService,
+        IConfirmationService confirmationService)
+        : base(logger, Constants.IdentityServicesGroup, "CleanClientOverlays",
+            "Strips overlay URI entries from every blueprint-managed client in the tenant. " +
+            "Without -overlayName: removes every Source matching 'overlay:*'. " +
+            "With -overlayName: removes only entries matching 'overlay:<name>' exactly. " +
+            "Destructive — typical use is before a sanitised DumpTenant export; the operator " +
+            "can re-apply with Apply-IdentityOverlay afterwards (idempotent, no-op if state matches).",
+            options, identityServicesClient, authenticationService)
+    {
+        _confirmationService = confirmationService;
+
+        _overlayName = CommandArgumentValue.AddArgument("n", "overlayName",
+            ["Optional overlay name. Without it, every 'overlay:*' source is removed. With it, " +
+             "only 'overlay:<name>' is removed. Same regex constraint as ApplyClientOverlay " +
+             "([A-Za-z0-9._-]+)."],
+            false, 1);
+        _yesArg = CommandArgumentValue.AddArgument("y", "yes", ["Skip confirmation prompt"], false, 0);
+    }
+
+    public override CommandDocumentation? GetDocumentation() =>
+        new(
+            Samples:
+            [
+                new CodeSample(
+                    arguments: [],
+                    description: "Strip every overlay:* entry from the active tenant (prompts for confirmation)"),
+                new CodeSample(
+                    arguments: [new CodeSampleArgument(_overlayName, "local-dev")],
+                    description: "Strip only overlay:local-dev entries; gerald-laptop and other overlays survive"),
+                new CodeSample(
+                    arguments: [new CodeSampleArgument(_yesArg)],
+                    description: "Skip the confirmation prompt — typical CI / dump-pipeline usage"),
+            ],
+            Notes:
+            [
+                "Idempotent — clients with nothing to remove skip the per-client UpdateAsync + cache invalidation.",
+                "base / api / family:* entries are always preserved; only overlay:* matches are removed.",
+                "Typical workflow before sharing a tenant dump: CleanClientOverlays -y → DumpTenant → Apply-IdentityOverlay (re-applies the canonical local-dev set from octo-tools/overlays/identity-local-dev.yaml).",
+            ]);
+
+    public override async Task Execute()
+    {
+        var overlayName = CommandArgumentValue.GetArgumentScalarValueOrDefault<string>(_overlayName);
+
+        var promptSubject = string.IsNullOrEmpty(overlayName)
+            ? "ALL overlay:* URI entries on every client"
+            : $"every overlay:{overlayName} URI entry on every client";
+
+        if (!CommandArgumentValue.IsArgumentUsed(_yesArg) &&
+            !_confirmationService.Confirm($"Are you sure you want to strip {promptSubject}?"))
+        {
+            throw ToolException.OperationCancelledByUser();
+        }
+
+        Logger.LogInformation(
+            "Stripping overlay entries (filter: {Filter}) at '{ServiceClientServiceUri}'",
+            string.IsNullOrEmpty(overlayName) ? "every overlay:*" : $"overlay:{overlayName}",
+            ServiceClient.ServiceUri);
+
+        var result = await ServiceClient.CleanOverlayEntries(overlayName);
+
+        Logger.LogInformation(
+            "Clean complete: {Total} entries removed across {Clients} client(s)",
+            result.TotalEntriesRemoved, result.ClientsAffected);
+
+        foreach (var clientResult in result.ClientResults)
+        {
+            Logger.LogInformation(
+                "  [{ClientId}] RedirectUris={R}, PostLogoutRedirectUris={PL}, AllowedCorsOrigins={CO}",
+                clientResult.ClientId,
+                clientResult.RedirectUrisRemoved,
+                clientResult.PostLogoutRedirectUrisRemoved,
+                clientResult.AllowedCorsOriginsRemoved);
+        }
+    }
+}

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -286,6 +286,8 @@ internal static class Program
 
         // AB#4209 Step 4 PR 2 — overlay URI write for blueprint-managed clients
         services.AddTransient<ICommand, ApplyClientOverlay>();
+        // AB#4209 Step 5 PR 4' — overlay URI cleanup (companion to ApplyClientOverlay)
+        services.AddTransient<ICommand, CleanClientOverlays>();
 
         services.AddTransient<ICommand, GetIdentityProviders>();
         services.AddTransient<ICommand, AddOAuthIdentityProvider>();


### PR DESCRIPTION
## Summary

[AB#4209](https://dev.azure.com/meshmakers/c85af059-45e1-40ff-9229-52bc69642d53/_workitems/edit/4209) Step 5 PR 4' — companion CLI command to `ApplyClientOverlay` (Step 4 PR 2). Wraps the identity-services `DELETE /v1/clients/cleanOverlayEntries` endpoint (shipped in #103, SDK-consumed via #38).

### Args

| Short | Long | Required | Description |
|-------|------|----------|-------------|
| `-n` | `--overlayName` | no | If omitted, strips every `overlay:*` source. If set, strips only `overlay:<name>` (same `[A-Za-z0-9._-]+` regex as ApplyClientOverlay). |
| `-y` | `--yes` | no | Skip the confirmation prompt — typical CI usage. |

### Output

Total entries removed + clients affected, followed by per-client per-list breakdown for clients that had matches. Idempotent — server skips `UpdateAsync` + cache invalidation for clients with nothing to remove.

## Wrapper-workflow recap

Step 5 was originally scoped as an atomic `DumpTenant --clean` flag with cross-service orchestration in bot-services. Discovery showed bot-services has zero existing cross-service HTTP clients — adding the first would require new OAuth client provisioning + secret management infrastructure. Pivoted to **two separate operator commands** instead:

```powershell
octo-cli -c CleanClientOverlays -y           # this PR
octo-cli -c DumpTenant -tid mytenant ...     # existing
Apply-IdentityOverlay                        # existing cmdlet, idempotent
```

The wrapper achieves the same end result without the atomic guarantee (brief window where overlays are gone from live tenant) but **zero new infrastructure**. Engine clone primitive (#108) stays merged as future foundation for the atomic path if/when `octo-platform-services` takes Phase 3 ownership.

## Revised Step 5 chain

| # | Repo | What | Status |
|---|------|------|--------|
| 1 | octo-identity-services | `DELETE cleanOverlayEntries` endpoint | ✅ merged #103 |
| 2 | octo-construction-kit-engine-mongodb | `CloneTenantToTempAsync` primitive | ✅ merged #108 (future foundation) |
| 3' | octo-sdk | DTOs lift + `IIdentityServicesClient.CleanOverlayEntries` | ✅ merged #38 |
| 4' (this) | octo-cli | `CleanClientOverlays` command | this PR |
| 5' | octo-identity-services | DTO cleanup — switch controller to SDK types, delete local file | pending |
| 6' | octo-documentation | workflow doc | pending |

## Test plan

- [x] `dotnet build Octo.Cli.sln -c DebugL` — green
- [x] `dotnet test Octo.Cli.sln -c DebugL` — 43/43 green
- [x] `octo-cli -c CleanClientOverlays` passes argument parser + DI registration
- [ ] CI green on this PR (depends on octo-sdk PR #38 NuGet being available — should be after the recent main build)
- [ ] End-to-end smoke against local Identity: invoke `CleanClientOverlays -y` after `Apply-IdentityOverlay`; verify entries are stripped and re-Apply restores them

🤖 Generated with [Claude Code](https://claude.com/claude-code)