### PR TITLE
AB#4230 cli: archive data export/import commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Environment variables are prefixed with `OCTO_`.
 |----------|----------|---------|
 | Identity | users, roles, clients (+ mirror commands: GetClientMirrors, ProvisionClientInExistingTenants, ProvisionClientInTenant, UnprovisionClientFromTenant, SetClientAutoProvision, ApplyClientOverlay, CleanClientOverlays), identityProviders, groups, emailDomainGroupRules, externalTenantUserMappings, adminProvisioning, apiResources, apiScopes | Identity Services |
 | Asset | tenants, models, blueprints (ListBlueprints, InstallBlueprint, GetBlueprintHistory, PreviewBlueprintUpdate, UpdateBlueprint, ListBlueprintBackups, RollbackBlueprint, ListBlueprintInstallations, UninstallBlueprint), timeSeries (EnableStreamData, DisableStreamData, ActivateArchive, DisableArchive, EnableArchive, RetryArchiveActivation, DeleteArchive, FreezeRollupArchive, UnfreezeRollupArchive, RewindRollupWatermark, ListRollupsForArchive) | Asset Repository |
-| Bots | Dump, Restore, RunFixupScripts | Bot Services |
+| Bots | Dump, Restore, ExportArchiveData, ImportArchiveData, RunFixupScripts | Bot Services |
 | Communication | enable/disable, adapters, pipelines (incl. MovePipelines for bulk reassignment to a different adapter), triggers, pools, dataFlows, workloads (GetWorkloadsByChart, UpdateWorkloadChartVersion, DeployWorkload, UndeployWorkload) | Communication Controller |
 | Reporting | enable/disable | Report Services |
 | AI Services | EnableAi, DisableAi, RedeemAiTicket (anonymous — bastion-side), GetAiCredentialsStatus, RevokeAiCredentials | AI Services |
@@ -210,6 +210,20 @@ octo-cli -c RetryArchiveActivation -id 69fda707d47638c68edc7fea # only from Fail
 octo-cli -c DeleteArchive -id 69fda707d47638c68edc7fea          # destructive — drops table, lose data
 octo-cli -c DeleteArchive -id 69fda707d47638c68edc7fea -y       # skip confirmation
 octo-cli -c DisableStreamData
+
+# Archive data export / import (AB#4230) — move archive row data between tenants/environments.
+# Export the whole archive to a ZIP (starts a bot job, waits, then downloads the result).
+octo-cli -c ExportArchiveData -tid mytenant -aid 69fda707d47638c68edc7fea -o ./archive-export.zip
+# Export only a half-open time slice [fromUtc, toUtc) (ISO-8601 UTC; omit both for whole archive).
+octo-cli -c ExportArchiveData -tid mytenant -aid 69fda707d47638c68edc7fea \
+  -from 2026-05-11T00:00:00Z -to 2026-05-12T00:00:00Z -o ./archive-slice.zip
+# Import a ZIP into a target archive. The target archive MUST be Disabled during import (§7.1):
+#   octo-cli -c DisableArchive -id <archiveRtId>
+#   octo-cli -c ImportArchiveData -tid mytenant -aid <archiveRtId> -i ./archive-export.zip -w
+#   octo-cli -c EnableArchive -id <archiveRtId>
+# Default mode is InsertOnly; use Upsert for windowed (time-range / rollup) archives.
+octo-cli -c ImportArchiveData -tid mytenant -aid 69fda707d47638c68edc7fea -i ./archive-export.zip -m Upsert -w
+# -w waits for the job to finish and surfaces the bot's error (schema mismatch / archive-not-Disabled) verbatim.
 
 # Rollup archive operations (rollup-archives concept §9)
 octo-cli -c ListRollupsForArchive -id <sourceArchiveRtId>       # list rollups attached to a source archive

--- a/src/ManagementTool/Commands/Implementations/Asset/TimeSeries/ExportArchiveData.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/TimeSeries/ExportArchiveData.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.BotServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Asset.TimeSeries;
+
+internal class ExportArchiveData : JobOctoCommand
+{
+    private readonly IArgument _tenantIdArg;
+    private readonly IArgument _archiveRtIdArg;
+    private readonly IArgument _fromUtcArg;
+    private readonly IArgument _toUtcArg;
+    private readonly IArgument _outputArg;
+
+    public ExportArchiveData(ILogger<ExportArchiveData> logger, IOptions<OctoToolOptions> options,
+        IBotServicesClient botServicesClient, IAuthenticationService authenticationService)
+        : base(logger, Constants.BotServicesGroup, "ExportArchiveData",
+            "Exports the row data of an archive to a downloadable ZIP. Omit both --fromUtc and --toUtc to export the whole archive; supply them to export the half-open slice [fromUtc, toUtc).",
+            options, botServicesClient,
+            authenticationService)
+    {
+        _tenantIdArg = CommandArgumentValue.AddArgument("tid", "tenantId", ["Id of tenant"],
+            true, 1);
+        _archiveRtIdArg = CommandArgumentValue.AddArgument("aid", "archiveRtId",
+            ["Runtime id of the CkArchive entity to export"], true, 1);
+        _fromUtcArg = CommandArgumentValue.AddArgument("from", "fromUtc",
+            ["Inclusive lower bound of the exported window, ISO-8601 UTC (e.g. 2026-05-11T14:00:00Z). Omit for whole archive."],
+            false, 1);
+        _toUtcArg = CommandArgumentValue.AddArgument("to", "toUtc",
+            ["Exclusive upper bound of the exported window, ISO-8601 UTC (e.g. 2026-05-12T14:00:00Z). Omit for whole archive."],
+            false, 1);
+        _outputArg = CommandArgumentValue.AddArgument("o", "output", ["Destination path of the export (*.zip)"], true, 1);
+    }
+
+    public override CommandDocumentation? GetDocumentation() =>
+        new(
+            Samples:
+            [
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_archiveRtIdArg, "69fda707d47638c68edc7fea"),
+                    new CodeSampleArgument(_outputArg, "./archive-export.zip"),
+                ],
+                    description: "Export the whole archive"),
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_archiveRtIdArg, "69fda707d47638c68edc7fea"),
+                    new CodeSampleArgument(_fromUtcArg, "2026-05-11T00:00:00Z"),
+                    new CodeSampleArgument(_toUtcArg, "2026-05-12T00:00:00Z"),
+                    new CodeSampleArgument(_outputArg, "./archive-slice.zip"),
+                ],
+                    description: "Export a time slice [fromUtc, toUtc)"),
+            ]
+        );
+
+    public override async Task Execute()
+    {
+        var tenantId = CommandArgumentValue.GetArgumentScalarValue<string>(_tenantIdArg).ToLower();
+        var archiveRtId = CommandArgumentValue.GetArgumentScalarValue<string>(_archiveRtIdArg);
+        var filePath = CommandArgumentValue.GetArgumentScalarValue<string>(_outputArg);
+
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw ToolException.NoTenantIdConfigured();
+        }
+
+        DateTime? fromUtc = null;
+        if (CommandArgumentValue.IsArgumentUsed(_fromUtcArg))
+        {
+            var fromRaw = CommandArgumentValue.GetArgumentScalarValue<string>(_fromUtcArg);
+            if (!DateTime.TryParse(fromRaw, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedFrom))
+            {
+                Logger.LogError("Could not parse 'fromUtc' value '{Raw}' as ISO-8601 timestamp.", fromRaw);
+                return;
+            }
+
+            fromUtc = parsedFrom;
+        }
+
+        DateTime? toUtc = null;
+        if (CommandArgumentValue.IsArgumentUsed(_toUtcArg))
+        {
+            var toRaw = CommandArgumentValue.GetArgumentScalarValue<string>(_toUtcArg);
+            if (!DateTime.TryParse(toRaw, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedTo))
+            {
+                Logger.LogError("Could not parse 'toUtc' value '{Raw}' as ISO-8601 timestamp.", toRaw);
+                return;
+            }
+
+            toUtc = parsedTo;
+        }
+
+        Logger.LogInformation(
+            "Exporting archive '{ArchiveRtId}' of tenant '{TenantId}' at '{ServiceClientServiceUri}' (from: {FromUtc}, to: {ToUtc})",
+            archiveRtId, tenantId, ServiceClient.ServiceUri, fromUtc?.ToString("O") ?? "<begin>",
+            toUtc?.ToString("O") ?? "<end>");
+
+        var response = await ServiceClient.StartExportArchiveDataAsync(tenantId, archiveRtId, fromUtc, toUtc);
+        Logger.LogInformation("Export with job id '{Id}' has been started", response.JobId);
+        await WaitForJob(response.JobId);
+
+        Logger.LogInformation(
+            "Export of archive '{ArchiveRtId}' of tenant '{TenantId}' at '{ServiceClientServiceUri}' created. Downloading...",
+            archiveRtId, tenantId, ServiceClient.ServiceUri);
+        await ServiceClient.DownloadDumpToFileAsync(tenantId, response.JobId, filePath,
+            bytesDownloaded =>
+            {
+                Logger.LogInformation("Downloaded {Bytes:N0} bytes", bytesDownloaded);
+            });
+        Logger.LogInformation("Archive export downloaded to '{FilePath}'", filePath);
+    }
+}

--- a/src/ManagementTool/Commands/Implementations/Asset/TimeSeries/ImportArchiveData.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/TimeSeries/ImportArchiveData.cs
@@ -1,0 +1,103 @@
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Octo.Communication.Contracts.DataTransferObjects;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.BotServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Asset.TimeSeries;
+
+internal class ImportArchiveData : JobWithWaitOctoCommand
+{
+    private readonly IArgument _tenantIdArg;
+    private readonly IArgument _archiveRtIdArg;
+    private readonly IArgument _inputArg;
+    private readonly IArgument _modeArg;
+
+    public ImportArchiveData(ILogger<ImportArchiveData> logger, IOptions<OctoToolOptions> options,
+        IBotServicesClient botServicesClient, IAuthenticationService authenticationService)
+        : base(logger, Constants.BotServicesGroup, "ImportArchiveData",
+            "Imports archive row data from an export ZIP into a target archive. The target archive must be Disabled during the import (see DisableArchive). The bot validates that the export schema matches the target archive before any rows are written.",
+            options, botServicesClient,
+            authenticationService)
+    {
+        _tenantIdArg = CommandArgumentValue.AddArgument("tid", "tenantId", ["Id of tenant"],
+            true, 1);
+        _archiveRtIdArg = CommandArgumentValue.AddArgument("aid", "archiveRtId",
+            ["Runtime id of the target CkArchive entity"], true, 1);
+        _inputArg = CommandArgumentValue.AddArgument("i", "input", ["Export file to import (*.zip)"], true, 1);
+        _modeArg = CommandArgumentValue.AddArgument("m", "mode",
+            ["Import mode: InsertOnly (default) or Upsert. Upsert is required for windowed (time-range / rollup) archives."],
+            false, 1);
+    }
+
+    public override CommandDocumentation? GetDocumentation() =>
+        new(
+            Samples:
+            [
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_archiveRtIdArg, "69fda707d47638c68edc7fea"),
+                    new CodeSampleArgument(_inputArg, "./archive-export.zip"),
+                    new CodeSampleArgument(_waitForJobArg),
+                ],
+                    description: "Import in InsertOnly mode (default)"),
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_archiveRtIdArg, "69fda707d47638c68edc7fea"),
+                    new CodeSampleArgument(_inputArg, "./archive-export.zip"),
+                    new CodeSampleArgument(_modeArg, "Upsert"),
+                    new CodeSampleArgument(_waitForJobArg),
+                ],
+                    description: "Import with upsert (required for windowed archives)"),
+            ],
+            Notes:
+            [
+                "The target archive must be Disabled during the import (use DisableArchive first, EnableArchive afterwards).",
+                "On failure the bot's error message (schema mismatch / archive-not-Disabled) is surfaced verbatim.",
+            ]
+        );
+
+    public override async Task Execute()
+    {
+        var tenantId = CommandArgumentValue.GetArgumentScalarValue<string>(_tenantIdArg).ToLower();
+        var archiveRtId = CommandArgumentValue.GetArgumentScalarValue<string>(_archiveRtIdArg);
+        var filePath = CommandArgumentValue.GetArgumentScalarValue<string>(_inputArg);
+
+        var mode = ArchiveImportMode.InsertOnly;
+        if (CommandArgumentValue.IsArgumentUsed(_modeArg))
+        {
+            var modeRaw = CommandArgumentValue.GetArgumentScalarValue<string>(_modeArg);
+            if (!Enum.TryParse(modeRaw, true, out mode))
+            {
+                Logger.LogError("Could not parse 'mode' value '{Raw}'. Valid values are: InsertOnly, Upsert.", modeRaw);
+                return;
+            }
+        }
+
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw ToolException.NoTenantIdConfigured();
+        }
+
+        if (!File.Exists(filePath))
+        {
+            throw ToolException.FilePathDoesNotExist(filePath);
+        }
+
+        Logger.LogInformation(
+            "Importing archive data into archive '{ArchiveRtId}' of tenant '{TenantId}' at '{ServiceClientServiceUri}' (mode: {Mode})",
+            archiveRtId, tenantId, ServiceClient.ServiceUri, mode);
+
+        var response = await ServiceClient.StartImportArchiveDataWithTusAsync(tenantId, archiveRtId, filePath, mode,
+            progress =>
+            {
+                Logger.LogInformation("Upload progress: {Progress:P0}", progress);
+            });
+        Logger.LogInformation("Upload complete. Import job with id '{Id}' has been started", response.JobId);
+        await WaitForJob(response.JobId);
+        Logger.LogInformation(
+            "Archive data imported into archive '{ArchiveRtId}' of tenant '{TenantId}' at '{ServiceClientServiceUri}'",
+            archiveRtId, tenantId, ServiceClient.ServiceUri);
+    }
+}

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -335,6 +335,8 @@ internal static class Program
         services.AddTransient<ICommand, UpdateSystemCkModelTenant>();
         services.AddTransient<ICommand, DumpTenant>();
         services.AddTransient<ICommand, RestoreTenant>();
+        services.AddTransient<ICommand, ExportArchiveData>();
+        services.AddTransient<ICommand, ImportArchiveData>();
 
         services.AddTransient<ICommand, GetUsers>();
         services.AddTransient<ICommand, CreateUser>();


### PR DESCRIPTION
Two CLI commands (Track E), mirroring tenant Dump/Restore via `IBotServicesClient`:
- `ExportArchiveData` (--tenantId --archiveRtId [--fromUtc --toUtc] --output): StartExportArchiveDataAsync → poll → DownloadDumpToFileAsync.
- `ImportArchiveData` (--tenantId --archiveRtId --input [--mode InsertOnly|Upsert]): StartImportArchiveDataWithTusAsync → poll. Surfaces bot error (schema mismatch / archive-not-Disabled §7.1) verbatim.
Build 0/0; 45/45 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)