### PR TITLE
AB#4231 cli: include/restore archive-data flags on Dump/Restore

### DIFF
--- a/src/ManagementTool/Commands/Implementations/Asset/Tenants/DumpTenant.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/Tenants/DumpTenant.cs
@@ -11,6 +11,7 @@ internal class DumpTenant : JobOctoCommand
 {
     private readonly IArgument _tenantIdArg;
     private readonly IArgument _fileArg;
+    private readonly IArgument _includeArchiveDataArg;
 
     public DumpTenant(ILogger<DumpTenant> logger, IOptions<OctoToolOptions> options,
         IBotServicesClient botServicesClient, IAuthenticationService authenticationService)
@@ -21,6 +22,9 @@ internal class DumpTenant : JobOctoCommand
         _tenantIdArg = CommandArgumentValue.AddArgument("tid", "tenantId", ["Id of tenant"],
             true, 1);
         _fileArg = CommandArgumentValue.AddArgument("f", "file", ["File of backup (*.tar.gz)"], true, 1);
+        _includeArchiveDataArg = CommandArgumentValue.AddArgument("iad", "include-archive-data",
+            ["Include CrateDB archive data in the dump. The produced backup is a larger '*.octobak.zip' artifact"],
+            false, 0);
     }
 
     public override CommandDocumentation? GetDocumentation() =>
@@ -32,6 +36,17 @@ internal class DumpTenant : JobOctoCommand
                     new CodeSampleArgument(_fileArg, "./backup.tar.gz"),
                 ],
                     description: "Basic usage"),
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_fileArg, "./backup.octobak.zip"),
+                    new CodeSampleArgument(_includeArchiveDataArg),
+                ],
+                    description: "Include CrateDB archive data (produces a larger '*.octobak.zip' artifact)"),
+            ],
+            Notes:
+            [
+                "Without --include-archive-data the backup is a plain '*.tar.gz' (MongoDB data only).",
+                "With --include-archive-data the produced artifact is a larger '*.octobak.zip' that also carries the CrateDB archive rows; pick a matching file name with -f.",
             ]
         );
 
@@ -39,16 +54,18 @@ internal class DumpTenant : JobOctoCommand
     {
         var tenantId = CommandArgumentValue.GetArgumentScalarValue<string>(_tenantIdArg).ToLower();
         var filePath = CommandArgumentValue.GetArgumentScalarValue<string>(_fileArg);
+        var includeArchiveData = CommandArgumentValue.IsArgumentUsed(_includeArchiveDataArg);
 
         Logger.LogInformation(
-            "Create dump of tenant \'{TenantId}\' at \'{ServiceClientServiceUri}\'", tenantId, ServiceClient.ServiceUri);
-        
+            "Create dump of tenant \'{TenantId}\' at \'{ServiceClientServiceUri}\' (include archive data: {IncludeArchiveData})",
+            tenantId, ServiceClient.ServiceUri, includeArchiveData);
+
         if (string.IsNullOrEmpty(tenantId))
         {
             throw ToolException.NoTenantIdConfigured();
         }
-        
-        var response = await ServiceClient.StartDumpRepositoryAsync(tenantId);
+
+        var response = await ServiceClient.StartDumpRepositoryAsync(tenantId, includeArchiveData);
         Logger.LogInformation("Create dump with job id \'{Id}\' has been started", response.JobId);
         await WaitForJob(response.JobId);
 

--- a/src/ManagementTool/Commands/Implementations/Asset/Tenants/RestoreTenant.cs
+++ b/src/ManagementTool/Commands/Implementations/Asset/Tenants/RestoreTenant.cs
@@ -13,6 +13,7 @@ internal class RestoreTenant : JobWithWaitOctoCommand
     private readonly IArgument _tenantIdArg;
     private readonly IArgument _fileArg;
     private readonly IArgument _oldDatabaseNameArg;
+    private readonly IArgument _restoreArchiveDataArg;
 
     public RestoreTenant(ILogger<RestoreTenant> logger, IOptions<OctoToolOptions> options,
         IBotServicesClient botServicesClient, IAuthenticationService authenticationService)
@@ -26,6 +27,9 @@ internal class RestoreTenant : JobWithWaitOctoCommand
             1);
         _fileArg = CommandArgumentValue.AddArgument("f", "file", ["File of backup (*.tar.gz)"], true, 1);
         _oldDatabaseNameArg = CommandArgumentValue.AddArgument("oldDb", "oldDatabaseName", ["Name of the old database (if different to new database name)"], false, 1);
+        _restoreArchiveDataArg = CommandArgumentValue.AddArgument("rad", "restore-archive-data",
+            ["Restore CrateDB archive data contained in an '*.octobak.zip' backup (no-op on a plain '*.tar.gz')"],
+            false, 0);
     }
 
     public override CommandDocumentation? GetDocumentation() =>
@@ -39,6 +43,19 @@ internal class RestoreTenant : JobWithWaitOctoCommand
                     new CodeSampleArgument(_waitForJobArg),
                 ],
                     description: "Basic usage"),
+                new CodeSample(arguments: [
+                    new CodeSampleArgument(_tenantIdArg, "mytenant"),
+                    new CodeSampleArgument(_databaseArg, "mytenant_db"),
+                    new CodeSampleArgument(_fileArg, "./backup.octobak.zip"),
+                    new CodeSampleArgument(_restoreArchiveDataArg),
+                    new CodeSampleArgument(_waitForJobArg),
+                ],
+                    description: "Restore CrateDB archive data from an '*.octobak.zip' backup"),
+            ],
+            Notes:
+            [
+                "--restore-archive-data restores archives to their backed-up state; it is a no-op on a plain '*.tar.gz' backup.",
+                "The target tenant's archive schemas must match those in the backup; mismatched archives are skipped and reported.",
             ]
         );
 
@@ -53,9 +70,11 @@ internal class RestoreTenant : JobWithWaitOctoCommand
             oldDatabaseName = CommandArgumentValue.GetArgumentScalarValue<string>(_oldDatabaseNameArg);
         }
 
+        var restoreArchiveData = CommandArgumentValue.IsArgumentUsed(_restoreArchiveDataArg);
+
         Logger.LogInformation(
-            "Restoring tenant \'{TenantId}\' (database \'{DatabaseName}\') at \'{ServiceClientServiceUri}\'. Old database name: \'{oldDatabaseName}\'", tenantId,
-            databaseName, ServiceClient.ServiceUri, oldDatabaseName ?? databaseName);
+            "Restoring tenant \'{TenantId}\' (database \'{DatabaseName}\') at \'{ServiceClientServiceUri}\'. Old database name: \'{oldDatabaseName}\', restore archive data: {RestoreArchiveData}", tenantId,
+            databaseName, ServiceClient.ServiceUri, oldDatabaseName ?? databaseName, restoreArchiveData);
 
         if (string.IsNullOrEmpty(tenantId))
         {
@@ -68,7 +87,8 @@ internal class RestoreTenant : JobWithWaitOctoCommand
         }
         
         var response = await ServiceClient.RestoreRepositoryWithTusAsync(tenantId, databaseName, filePath, oldDatabaseName,
-            progress =>
+            restoreArchiveData: restoreArchiveData,
+            progressCallback: progress =>
             {
                 Logger.LogInformation("Upload progress: {Progress:P0}", progress);
             });


### PR DESCRIPTION
Dump gains --include-archive-data/-iad → StartDumpRepositoryAsync(tenantId, includeArchiveData) (.octobak.zip). Restore gains --restore-archive-data/-rad → RestoreRepositoryWithTusAsync(..., restoreArchiveData:, ...) (no-op on plain .tar.gz; mismatched archive schemas skipped+reported). Build 0/0; 45/45 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)