### PR TITLE
AB#4417 New: Add DeployPool command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,7 @@ All communication commands accept plain runtime object IDs (e.g. `69cfa838092b71
 | Command | Parameters | Description |
 |---------|-----------|-------------|
 | `GetPools` | `--json` (optional) | List all pools for the tenant |
+| `DeployPool` | `-id <poolRtId>` | Trigger pool deploy (operator creates the CommunicationPool CR); workloads deploy separately |
 
 ### Data Flows
 

--- a/src/ManagementTool/Commands/Implementations/Communication/DeployPoolCommand.cs
+++ b/src/ManagementTool/Commands/Implementations/Communication/DeployPoolCommand.cs
@@ -22,6 +22,12 @@ internal class DeployPoolCommand : ServiceClientOctoCommand<ICommunicationServic
 
     public override async Task Execute()
     {
+        if (string.IsNullOrWhiteSpace(Options.Value.TenantId))
+        {
+            Logger.LogError("TenantId is missing");
+            return;
+        }
+
         var poolRtId = CommandArgumentValue.GetArgumentScalarValue<string>(_poolRtId);
 
         Logger.LogInformation(

--- a/src/ManagementTool/Commands/Implementations/Communication/DeployPoolCommand.cs
+++ b/src/ManagementTool/Commands/Implementations/Communication/DeployPoolCommand.cs
@@ -1,0 +1,35 @@
+using Meshmakers.Common.CommandLineParser;
+using Meshmakers.Octo.Frontend.ManagementTool.Services;
+using Meshmakers.Octo.Sdk.ServiceClient.CommunicationControllerServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Meshmakers.Octo.Frontend.ManagementTool.Commands.Implementations.Communication;
+
+internal class DeployPoolCommand : ServiceClientOctoCommand<ICommunicationServicesClient>
+{
+    private readonly IArgument _poolRtId;
+
+    public DeployPoolCommand(ILogger<DeployPoolCommand> logger, IOptions<OctoToolOptions> options,
+        ICommunicationServicesClient communicationServicesClient, IAuthenticationService authenticationService)
+        : base(logger, Constants.CommunicationServicesGroup, "DeployPool",
+            "Triggers a deploy of a pool. The Communication Operator creates the pool resources; workloads are deployed separately via DeployWorkload.",
+            options, communicationServicesClient, authenticationService)
+    {
+        _poolRtId = CommandArgumentValue.AddArgument("id", "poolRtId",
+            ["The pool's runtime object ID"], true, 1);
+    }
+
+    public override async Task Execute()
+    {
+        var poolRtId = CommandArgumentValue.GetArgumentScalarValue<string>(_poolRtId);
+
+        Logger.LogInformation(
+            "Deploying pool '{PoolRtId}' for tenant '{TenantId}' at '{ServiceClientServiceUri}'",
+            poolRtId, Options.Value.TenantId, ServiceClient.ServiceUri);
+
+        await ServiceClient.DeployPoolAsync(poolRtId);
+
+        Logger.LogInformation("Pool '{PoolRtId}' deploy triggered", poolRtId);
+    }
+}

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -428,6 +428,7 @@ internal static class Program
         services.AddTransient<ICommand, GetWorkloadsByChartCommand>();
         services.AddTransient<ICommand, UpdateWorkloadChartVersionCommand>();
         services.AddTransient<ICommand, DeployWorkloadCommand>();
+        services.AddTransient<ICommand, DeployPoolCommand>();
         services.AddTransient<ICommand, UndeployWorkloadCommand>();
         services.AddTransient<ICommand, MovePipelinesToAdapterCommand>();
 

--- a/src/ManagementTool/Program.cs
+++ b/src/ManagementTool/Program.cs
@@ -418,6 +418,7 @@ internal static class Program
 
         // Communication - Pools
         services.AddTransient<ICommand, GetPoolsCommand>();
+        services.AddTransient<ICommand, DeployPoolCommand>();
 
         // Communication - Data Flows
         services.AddTransient<ICommand, DeployDataFlowCommand>();
@@ -428,7 +429,6 @@ internal static class Program
         services.AddTransient<ICommand, GetWorkloadsByChartCommand>();
         services.AddTransient<ICommand, UpdateWorkloadChartVersionCommand>();
         services.AddTransient<ICommand, DeployWorkloadCommand>();
-        services.AddTransient<ICommand, DeployPoolCommand>();
         services.AddTransient<ICommand, UndeployWorkloadCommand>();
         services.AddTransient<ICommand, MovePipelinesToAdapterCommand>();
 


### PR DESCRIPTION
Adds the `DeployPool` command (Communication group, `-id <poolRtId>`), mirroring `DeployWorkload`: triggers a pool deploy so the Communication Operator creates the CommunicationPool resource; workloads deploy separately via `DeployWorkload`. Registered under the Pools command block; documented in CLAUDE.md.

Depends on the octo-sdk `DeployPoolAsync` PR — merge that first; this PR's CI needs the updated SDK package on the feed (an initial red restore resolves by re-running checks after the octo-sdk main build publishes).

[AB#4417](https://dev.azure.com/meshmakers/c85af059-45e1-40ff-9229-52bc69642d53/_workitems/edit/4417)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
